### PR TITLE
Fix javax.annotation.Resource

### DIFF
--- a/geronimo-annotation_1.2_spec/src/main/java/javax/annotation/Resource.java
+++ b/geronimo-annotation_1.2_spec/src/main/java/javax/annotation/Resource.java
@@ -43,7 +43,7 @@ public @interface Resource {
 
     String name() default "";
 
-    Class type() default Object.class;
+    Class<?> type() default Object.class;
 
     AuthenticationType authenticationType()
             default AuthenticationType.CONTAINER;

--- a/geronimo-annotation_1.3_spec/src/main/java/javax/annotation/Resource.java
+++ b/geronimo-annotation_1.3_spec/src/main/java/javax/annotation/Resource.java
@@ -42,7 +42,7 @@ public @interface Resource {
 
     String name() default "";
 
-    Class type() default Object.class;
+    Class<?> type() default Object.class;
 
     AuthenticationType authenticationType()
             default AuthenticationType.CONTAINER;


### PR DESCRIPTION
Starting with JSR250 maintenance release 2, the signature of Resource.type() is changed to return "Class<?>"  instead of "Class": https://jcp.org/en/jsr/detail?id=250