### PR TITLE
[GERONIMO-6601] adds Automatic-Module-Name

### DIFF
--- a/geronimo-activation_1.1_spec/pom.xml
+++ b/geronimo-activation_1.1_spec/pom.xml
@@ -49,6 +49,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.activation</automatic.module.name>
     </properties>
 
     <scm>
@@ -108,6 +109,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator,org.apache.geronimo.specs.activation</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.specs.activation.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-annotation_1.0-MR1_spec/pom.xml
+++ b/geronimo-annotation_1.0-MR1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.annotation</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.annotation*;version=1.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-annotation_1.0_spec/pom.xml
+++ b/geronimo-annotation_1.0_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.annotation</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.annotation*;version=1.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-annotation_1.1_spec/pom.xml
+++ b/geronimo-annotation_1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.annotation</automatic.module.name>
     </properties>
 
     <scm>
@@ -68,6 +69,17 @@
                         <Specification-Version>1.1</Specification-Version>
                         <Export-Package>javax.annotation*;version=1.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-annotation_1.2_spec/pom.xml
+++ b/geronimo-annotation_1.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.annotation</automatic.module.name>
     </properties>
 
     <scm>
@@ -69,6 +70,17 @@
                         <Specification-Version>1.2</Specification-Version>
                         <Export-Package>javax.annotation*;version=1.2</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-annotation_1.3_spec/pom.xml
+++ b/geronimo-annotation_1.3_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.annotation</automatic.module.name>
     </properties>
 
     <scm>
@@ -69,6 +70,17 @@
                         <Specification-Version>1.3</Specification-Version>
                         <Export-Package>javax.annotation*;version=1.3</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-atinject_1.0_spec/pom.xml
+++ b/geronimo-atinject_1.0_spec/pom.xml
@@ -43,6 +43,10 @@
         </site>
     </distributionManagement>
 
+    <properties>
+        <automatic.module.name>javax.inject</automatic.module.name>
+    </properties>
+
     <scm>
         <connection>scm:svn:http://svn.apache.org/repos/asf/geronimo/specs/trunk/geronimo-atinject_1.0_spec/</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/geronimo/specs/trunk/geronimo-atinject_1.0_spec/</developerConnection>
@@ -58,6 +62,17 @@
                     <instructions>
                         <Export-Package>javax.inject*;version=1.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-availability_0.4_spec/pom.xml
+++ b/geronimo-availability_0.4_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.availability.management</automatic.module.name>
     </properties>
 
     <scm>
@@ -65,6 +66,17 @@
                 <instructions>
                   <Export-Package>javax.availability.management*;version=0.4</Export-Package>
                 </instructions>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
             </configuration>
         </plugin>
       </plugins>

--- a/geronimo-availability_1.0_spec/pom.xml
+++ b/geronimo-availability_1.0_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.availability.management</automatic.module.name>
     </properties>
 
     <scm>
@@ -65,6 +66,17 @@
                 <instructions>
                   <Export-Package>javax.availability.management*;version=1.0</Export-Package>
                 </instructions>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
             </configuration>
         </plugin>
       </plugins>

--- a/geronimo-ccpp_1.0_spec/pom.xml
+++ b/geronimo-ccpp_1.0_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.ccpp</automatic.module.name>
     </properties>
 
     <scm>
@@ -81,6 +82,17 @@
                     <instructions>
                         <Export-Package>javax.ccpp*;version=1.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-commonj_1.1_spec/pom.xml
+++ b/geronimo-commonj_1.1_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>commonj</automatic.module.name>
     </properties>
 
     <scm>
@@ -66,6 +67,17 @@
                         <!-- TODO import and export of java packages cannot be specified.  Is this really a java spec rather than javax?? -->
                         <Export-Package>java.commonj*;version=1.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-concurrent_1.0_spec/pom.xml
+++ b/geronimo-concurrent_1.0_spec/pom.xml
@@ -51,6 +51,7 @@
 
     <geronimo.osgi.export.pkg>javax.enterprise.concurrent*</geronimo.osgi.export.pkg>
     <geronimo.osgi.export.version>1.0</geronimo.osgi.export.version>
+    <automatic.module.name>javax.enterprise.concurrent</automatic.module.name>
   </properties>
 
   <scm>
@@ -69,6 +70,17 @@
           <instructions>
             <Export-Package>javax.enterprise.concurrent*;version=1.0</Export-Package>
           </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/geronimo-ejb_3.0_spec/pom.xml
+++ b/geronimo-ejb_3.0_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.ejb</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -88,6 +89,17 @@
                         <!-- TODO how about javax.xml.rpc.handler which is in this jar?? -->
                         <Export-Package>javax.ejb*;version=3.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-ejb_3.1_spec-alt/pom.xml
+++ b/geronimo-ejb_3.1_spec-alt/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.ejb</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -100,7 +101,17 @@
                     </instructions>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/geronimo-ejb_3.1_spec/pom.xml
+++ b/geronimo-ejb_3.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.ejb</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -108,6 +109,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-ejb_3.2_spec/pom.xml
+++ b/geronimo-ejb_3.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.ejb</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -108,6 +109,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-el_1.0_spec/pom.xml
+++ b/geronimo-el_1.0_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.el</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.el*;version=1.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-el_2.2_spec/pom.xml
+++ b/geronimo-el_2.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${project.artifactId}</siteId>
+        <automatic.module.name>javax.el</automatic.module.name>
     </properties>
 
     <scm>
@@ -80,6 +81,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-interceptor_1.1_spec/pom.xml
+++ b/geronimo-interceptor_1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.interceptor</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.interceptor*;version=1.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-interceptor_1.2_spec/pom.xml
+++ b/geronimo-interceptor_1.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${project.artifactId}</siteId>
+        <automatic.module.name>javax.interceptor</automatic.module.name>
     </properties>
 
     <scm>
@@ -65,6 +66,17 @@
                     <instructions>
                         <Export-Package>javax.interceptor*;version=1.2</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-interceptor_3.0_spec/pom.xml
+++ b/geronimo-interceptor_3.0_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.interceptor</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.interceptor*;version=3.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-j2ee-connector_1.6_spec/pom.xml
+++ b/geronimo-j2ee-connector_1.6_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.resource</automatic.module.name>
     </properties>
 
     <scm>
@@ -79,6 +80,17 @@
                     <instructions>
                         <Export-Package>javax.resource*;version=1.6</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-j2ee-deployment_1.1_spec/pom.xml
+++ b/geronimo-j2ee-deployment_1.1_spec/pom.xml
@@ -46,6 +46,7 @@
     </distributionManagement>
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.enterprise.deploy</automatic.module.name>
     </properties>
 
     <scm>
@@ -72,6 +73,17 @@
                 <instructions>
                   <Export-Package>javax.enterprise.deploy*;version=1.1</Export-Package>
                 </instructions>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
             </configuration>
         </plugin>
       </plugins>

--- a/geronimo-j2ee-management_1.1_spec/pom.xml
+++ b/geronimo-j2ee-management_1.1_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.management.j2ee</automatic.module.name>
     </properties>
 
     <scm>
@@ -81,6 +82,17 @@
                         <Export-Package>javax.management.j2ee*;version=1.1</Export-Package>
                         <Import-Package>javax.ejb*;resolution:=optional;version=2.1,*</Import-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jacc_1.1_spec/pom.xml
+++ b/geronimo-jacc_1.1_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.security.jacc</automatic.module.name>
     </properties>
 
     <scm>
@@ -93,6 +94,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jacc_1.4_spec/pom.xml
+++ b/geronimo-jacc_1.4_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.security.jacc</automatic.module.name>
     </properties>
 
     <scm>
@@ -93,6 +94,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaspic_1.0_spec/pom.xml
+++ b/geronimo-jaspic_1.0_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.security.auth.message</automatic.module.name>
     </properties>
 
     <scm>
@@ -80,6 +81,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-javaee-deployment_1.1MR3_spec/pom.xml
+++ b/geronimo-javaee-deployment_1.1MR3_spec/pom.xml
@@ -46,6 +46,7 @@
     </distributionManagement>
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.enterprise.deploy</automatic.module.name>
     </properties>
 
     <scm>
@@ -72,6 +73,17 @@
                 <instructions>
                   <Export-Package>javax.enterprise.deploy*;version=1.1.3</Export-Package>
                 </instructions>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+                <archive>
+                    <manifestEntries>
+                        <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                    </manifestEntries>
+                </archive>
             </configuration>
         </plugin>
       </plugins>

--- a/geronimo-javamail_1.4_spec/pom.xml
+++ b/geronimo-javamail_1.4_spec/pom.xml
@@ -50,6 +50,7 @@
         <siteId>specs/${project.artifactId}</siteId>
         <geronimo.osgi.private.pkg>org.apache.geronimo.mail*</geronimo.osgi.private.pkg>
         <geronimo.osgi.resources>src/main/resources/,META-INF/LICENSE.txt=LICENSE.txt,META-INF/NOTICE.txt=NOTICE.txt</geronimo.osgi.resources>
+        <automatic.module.name>javax.mail</automatic.module.name>
     </properties>
 
     <scm>
@@ -168,6 +169,17 @@
                     </goals>
                   </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/geronimo-javamail_1.5_spec/pom.xml
+++ b/geronimo-javamail_1.5_spec/pom.xml
@@ -50,6 +50,7 @@
         <siteId>specs/${project.artifactId}</siteId>
         <geronimo.osgi.private.pkg>org.apache.geronimo.mail*</geronimo.osgi.private.pkg>
         <geronimo.osgi.resources>src/main/resources/,META-INF/LICENSE.txt=LICENSE.txt,META-INF/NOTICE.txt=NOTICE.txt</geronimo.osgi.resources>
+        <automatic.module.name>javax.mail</automatic.module.name>
     </properties>
 
     <scm>
@@ -144,6 +145,17 @@
                                 <!--RAT doesn't seem to recognize MIT style licenses-->
                                 <exclude>manual/src/styles/print.css</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/geronimo-jaxb_2.0_spec/pom.xml
+++ b/geronimo-jaxb_2.0_spec/pom.xml
@@ -44,6 +44,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.bind</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -76,6 +77,17 @@
                     <instructions>
                         <Export-Package>javax.xml.bind*;version=2.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxb_2.1_spec/pom.xml
+++ b/geronimo-jaxb_2.1_spec/pom.xml
@@ -44,6 +44,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.bind</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -76,6 +77,17 @@
                     <instructions>
                         <Export-Package>javax.xml.bind*;version=2.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxb_2.2_spec/pom.xml
+++ b/geronimo-jaxb_2.2_spec/pom.xml
@@ -44,6 +44,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.bind</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -89,6 +90,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxr_1.0_spec/pom.xml
+++ b/geronimo-jaxr_1.0_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.registry</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -101,6 +102,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxrpc_1.1_spec/pom.xml
+++ b/geronimo-jaxrpc_1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.rpc</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -94,6 +95,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxrs_1.1_spec/pom.xml
+++ b/geronimo-jaxrs_1.1_spec/pom.xml
@@ -45,6 +45,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.ws.rs</automatic.module.name>
     </properties>
 
     <scm>
@@ -78,6 +79,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxrs_2.0_spec/pom.xml
+++ b/geronimo-jaxrs_2.0_spec/pom.xml
@@ -45,6 +45,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.ws.rs</automatic.module.name>
   </properties>
 
   <scm>
@@ -79,6 +80,17 @@
             <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
             <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
           </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/geronimo-jaxrs_2.1_spec/pom.xml
+++ b/geronimo-jaxrs_2.1_spec/pom.xml
@@ -45,6 +45,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.ws.rs</automatic.module.name>
   </properties>
 
   <scm>
@@ -79,6 +80,17 @@
             <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
             <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
           </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/geronimo-jaxws_2.1.1_spec/pom.xml
+++ b/geronimo-jaxws_2.1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.ws</automatic.module.name>
     </properties>
 
     <scm>
@@ -104,6 +105,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxws_2.1_spec/pom.xml
+++ b/geronimo-jaxws_2.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.ws</automatic.module.name>
     </properties>
 
     <scm>
@@ -91,6 +92,17 @@
                     <instructions>
                         <Export-Package>javax.xml.ws*;version=2.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jaxws_2.2_spec/pom.xml
+++ b/geronimo-jaxws_2.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.ws</automatic.module.name>
     </properties>
 
     <scm>
@@ -108,6 +109,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jbatch_1.0_spec/pom.xml
+++ b/geronimo-jbatch_1.0_spec/pom.xml
@@ -42,6 +42,7 @@
 
     <properties>
         <siteId>specs/${project.artifactId}</siteId>
+        <automatic.module.name>javax.batch</automatic.module.name>
     </properties>
 
     <scm>
@@ -99,6 +100,17 @@
                 <configuration>
                     <target>1.6</target>
                     <source>1.6</source>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jcache_1.0_spec/pom.xml
+++ b/geronimo-jcache_1.0_spec/pom.xml
@@ -42,6 +42,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.cache</automatic.module.name>
   </properties>
 
   <scm>
@@ -99,6 +100,17 @@
               javax.cache*;version=1.0
             </Export-Package>
           </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/geronimo-jcdi_1.0_spec/pom.xml
+++ b/geronimo-jcdi_1.0_spec/pom.xml
@@ -42,6 +42,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.decorator</automatic.module.name>
     </properties>
 
     <scm>
@@ -110,6 +111,17 @@
                             javax.enterprise.util*;version=1.0
                         </Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jcdi_1.1_spec/pom.xml
+++ b/geronimo-jcdi_1.1_spec/pom.xml
@@ -44,6 +44,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.decorator</automatic.module.name>
     </properties>
 
     <scm>
@@ -113,6 +114,17 @@
                             javax.enterprise.util*;version=1.0
                         </Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jcdi_2.0_spec/pom.xml
+++ b/geronimo-jcdi_2.0_spec/pom.xml
@@ -44,6 +44,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.decorator</automatic.module.name>
     </properties>
 
     <scm>
@@ -128,6 +129,17 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jms_1.1_spec/pom.xml
+++ b/geronimo-jms_1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.jms</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -87,6 +88,17 @@
                     <instructions>
                         <Export-Package>javax.jms*;version=1.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jms_2.0_spec/pom.xml
+++ b/geronimo-jms_2.0_spec/pom.xml
@@ -49,6 +49,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.jms</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -111,6 +112,17 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/geronimo-jpa_1.0_spec/pom.xml
+++ b/geronimo-jpa_1.0_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.persistence</automatic.module.name>
     </properties>
 
     <scm>
@@ -68,6 +69,17 @@
                         <Specification-Version>1.0</Specification-Version>
                         <Export-Package>javax.persistence*;version=1.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jpa_2.0_spec/pom.xml
+++ b/geronimo-jpa_2.0_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.persistence</automatic.module.name>
     </properties>
 
     <scm>
@@ -160,6 +161,17 @@
                         </Import-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jpa_2.1_spec/pom.xml
+++ b/geronimo-jpa_2.1_spec/pom.xml
@@ -49,6 +49,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.persistence</automatic.module.name>
   </properties>
 
   <scm>
@@ -152,6 +153,17 @@
             </Import-Package>
           </instructions>
           <unpackBundle>true</unpackBundle>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/geronimo-json_1.0_spec/pom.xml
+++ b/geronimo-json_1.0_spec/pom.xml
@@ -42,6 +42,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.json</automatic.module.name>
   </properties>
 
   <scm>
@@ -125,6 +126,17 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/geronimo-json_1.1_spec/pom.xml
+++ b/geronimo-json_1.1_spec/pom.xml
@@ -42,6 +42,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.json</automatic.module.name>
   </properties>
 
   <scm>
@@ -111,6 +112,17 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/geronimo-jsonb_1.0_spec/pom.xml
+++ b/geronimo-jsonb_1.0_spec/pom.xml
@@ -42,6 +42,7 @@
 
     <properties>
         <siteId>specs/${project.artifactId}</siteId>
+        <automatic.module.name>javax.json.bind</automatic.module.name>
     </properties>
 
     <scm>
@@ -124,6 +125,17 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/geronimo-jsp_2.1_spec/pom.xml
+++ b/geronimo-jsp_2.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.servlet.jsp</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -79,6 +80,17 @@
                     <instructions>
                         <Export-Package>javax.servlet.jsp*;version=2.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jsp_2.2_spec/pom.xml
+++ b/geronimo-jsp_2.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.servlet.jsp</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -79,6 +80,17 @@
                     <instructions>
                         <Export-Package>javax.servlet.jsp*;version=2.2</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jta_1.1_spec/pom.xml
+++ b/geronimo-jta_1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.transaction</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.transaction*;version=1.1</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-jta_1.2_spec/pom.xml
+++ b/geronimo-jta_1.2_spec/pom.xml
@@ -47,6 +47,7 @@
 
   <properties>
     <siteId>specs/${project.artifactId}</siteId>
+    <automatic.module.name>javax.transaction</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -81,6 +82,17 @@
           <instructions>
             <Export-Package>javax.transaction*;version=1.2</Export-Package>
           </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
     </plugins>

--- a/geronimo-osgi-support/pom.xml
+++ b/geronimo-osgi-support/pom.xml
@@ -51,6 +51,7 @@ OSGi-specific lookup in the Geronimo spec projects.
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>org.apache.geronimo.osgi</automatic.module.name>
     </properties>
 
     <scm>
@@ -179,6 +180,17 @@ OSGi-specific lookup in the Geronimo spec projects.
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <failIfNoTests>false</failIfNoTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
                     </configuration>
                 </plugin>
             </plugins>

--- a/geronimo-saaj_1.3_spec/pom.xml
+++ b/geronimo-saaj_1.3_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml.soap</automatic.module.name>
     </properties>
 
     <dependencies>
@@ -86,6 +87,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-servlet_2.5_spec/pom.xml
+++ b/geronimo-servlet_2.5_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.servlet</automatic.module.name>
     </properties>
 
     <scm>
@@ -64,6 +65,17 @@
                     <instructions>
                         <Export-Package>javax.servlet*;version=2.5</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-servlet_3.0_spec/pom.xml
+++ b/geronimo-servlet_3.0_spec/pom.xml
@@ -49,6 +49,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.servlet</automatic.module.name>
     </properties>
 
     <scm>
@@ -126,6 +127,28 @@
                                 <!--RAT doesn't seem to recognize MIT style licenses-->
                                 <exclude>manual/src/styles/print.css</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <automatic.module.name>javax.servlet</automatic.module.name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/geronimo-servlet_3.1_spec/pom.xml
+++ b/geronimo-servlet_3.1_spec/pom.xml
@@ -49,6 +49,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.servlet</automatic.module.name>
     </properties>
 
     <scm>
@@ -144,6 +145,17 @@
                                 <!--RAT doesn't seem to recognize MIT style licenses-->
                                 <exclude>manual/src/styles/print.css</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/geronimo-stax-api_1.0_spec/pom.xml
+++ b/geronimo-stax-api_1.0_spec/pom.xml
@@ -50,6 +50,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml</automatic.module.name>
     </properties>
 
     <scm>
@@ -83,6 +84,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-stax-api_1.2_spec/pom.xml
+++ b/geronimo-stax-api_1.2_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.xml</automatic.module.name>
     </properties>
 
     <scm>
@@ -81,6 +82,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-validation_1.0_spec/pom.xml
+++ b/geronimo-validation_1.0_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.validation</automatic.module.name>
     </properties>
 
     <scm>
@@ -91,6 +92,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-validation_1.1_spec/pom.xml
+++ b/geronimo-validation_1.1_spec/pom.xml
@@ -47,6 +47,7 @@
 
     <properties>
         <siteId>specs/${project.artifactId}</siteId>
+        <automatic.module.name>javax.validation</automatic.module.name>
     </properties>
 
     <scm>
@@ -111,6 +112,17 @@
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-validation_2.0_spec/pom.xml
+++ b/geronimo-validation_2.0_spec/pom.xml
@@ -48,6 +48,7 @@
 
     <properties>
         <siteId>specs/${project.artifactId}</siteId>
+        <automatic.module.name>javax.validation</automatic.module.name>
     </properties>
 
     <scm>
@@ -113,8 +114,18 @@
                         <Import-Package>org.apache.geronimo.osgi.registry.api;resolution:=optional,*</Import-Package>
                         <Private-Package>org.apache.geronimo.osgi.locator</Private-Package>
                         <Bundle-Activator>org.apache.geronimo.osgi.locator.Activator</Bundle-Activator>
-                        <Automatic-Module-Name>java.validation</Automatic-Module-Name>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/geronimo-websockets_1.0_spec/pom.xml
+++ b/geronimo-websockets_1.0_spec/pom.xml
@@ -49,6 +49,7 @@
 
     <properties>
         <siteId>specs/${artifactId}</siteId>
+        <automatic.module.name>javax.websocket</automatic.module.name>
     </properties>
 
     <scm>
@@ -107,6 +108,17 @@
                                 <!--RAT doesn't seem to recognize MIT style licenses-->
                                 <exclude>manual/src/styles/print.css</exclude>
                             </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/geronimo-ws-metadata_2.0_spec/pom.xml
+++ b/geronimo-ws-metadata_2.0_spec/pom.xml
@@ -50,6 +50,7 @@
 
         <geronimo.osgi.export.pkg>javax.jws*</geronimo.osgi.export.pkg>
         <geronimo.osgi.export.version>2.0</geronimo.osgi.export.version>
+        <automatic.module.name>javax.jws</automatic.module.name>
     </properties>
 
     <scm>
@@ -67,6 +68,17 @@
                     <instructions>
                         <Export-Package>javax.jws*;version=2.0</Export-Package>
                     </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
the duplication of the maven-jar-plugin configuration in every module pom.xml seems required with the current project hierarchy.  

The value of  
```xml
<Automatic-Module-Name>
``` 
is set in a property `<automatic.module.name>` in the event that this should change.

The property values are consistent with the top-level exported package name with a few exceptions.  Several specs export more than one primary package, for example, `geronimo-jcdi_1.0_spec`, that exports
`javax.decorator` and  `javax.enterprise`.  In that case, I arbitrarily chose `javax.decorator`. 