### PR TITLE
GERONIMO-6751 JSON-P 1.1 incompliance: EmptyJsonObject incorrectly an…

### DIFF
--- a/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonObject.java
+++ b/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonObject.java
@@ -49,12 +49,12 @@ class EmptyJsonObject extends AbstractMap<String, JsonValue> implements JsonObje
 
     @Override
     public String getString(String name) {
-        return null;
+        throw new NullPointerException("Calling getString on EmptyJsonObject");
     }
 
     @Override
     public String getString(String name, String defaultValue) {
-        return null;
+        return defaultValue;
     }
 
     @Override
@@ -79,7 +79,7 @@ class EmptyJsonObject extends AbstractMap<String, JsonValue> implements JsonObje
 
     @Override
     public boolean isNull(String name) {
-        return true;
+        throw new NullPointerException("Calling isNull on EmptyJsonObject");
     }
 
     @Override


### PR DESCRIPTION
1.
* The [JSON-P API](https://github.com/eclipse-ee4j/jsonp/blob/5735bb62715578633d5721bf583b837506bbec73/api/src/main/java/javax/json/JsonObject.java#L164-L165) requires `JsonObject.getString("missing")` to throw `NullPointerException` for non-existent key `"missing"`.
* [Geronimo](https://github.com/apache/geronimo-specs/blob/0f0956795ad0839ec698e11fd3a7049f0114623c/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonObject.java#L51-L52)'s variant of the JSON-P API (`EmptyJsonObject`) **incorrectly** returns `null` instead of throwing an exception.

2.
* The [JSON-P API](https://github.com/eclipse-ee4j/jsonp/blob/5735bb62715578633d5721bf583b837506bbec73/api/src/main/java/javax/json/JsonObject.java#L172-L175) requires `JsonObject.getString("missing", "default")` to return `"default"` for non-existent key `"missing"`.
* [Geronimo](https://github.com/apache/geronimo-specs/blob/0f0956795ad0839ec698e11fd3a7049f0114623c/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonObject.java#L55-L58)'s variant of the JSON-P API (`EmptyJsonObject`) **incorrectly** returns `null` instead of `"default"`.

3.
* The [JSON-P API](https://github.com/eclipse-ee4j/jsonp/blob/5735bb62715578633d5721bf583b837506bbec73/api/src/main/java/javax/json/JsonObject.java#L244-L245) requires `JsonObject.isNull("missing")` to throw `NullPointerException` for non-existent key `"missing"`.
* [Geronimo](https://github.com/apache/geronimo-specs/blob/0f0956795ad0839ec698e11fd3a7049f0114623c/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonObject.java#L80-L83)'s variant of the JSON-P API (`EmptyJsonObject`) **incorrectly** returns `true` instead of throwing an exception.