### PR TITLE
Empty JSON array should return empty list views instead of null

### DIFF
--- a/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonArray.java
+++ b/geronimo-json_1.1_spec/src/main/java/javax/json/EmptyJsonArray.java
@@ -18,6 +18,7 @@ package javax.json;
 
 import java.io.Serializable;
 import java.util.AbstractList;
+import java.util.Collections;
 import java.util.List;
 
 class EmptyJsonArray extends AbstractList<JsonValue> implements JsonArray, Serializable {
@@ -53,7 +54,7 @@ class EmptyJsonArray extends AbstractList<JsonValue> implements JsonArray, Seria
 
     @Override
     public <T extends JsonValue> List<T> getValuesAs(Class<T> clazz) {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
The current implementation of `getValuesAs()` returns null. This is unexpected, since empty collections should return empty views instead of null. I imagine there are people who pass this call to an enhanced for loop without an extra null check, so this seems dangerous as well.